### PR TITLE
fix error in start_workflow call inside periodic modules

### DIFF
--- a/mistral/services/periodic.py
+++ b/mistral/services/periodic.py
@@ -42,7 +42,7 @@ class MistralPeriodicTasks(periodic_task.PeriodicTasks):
                 rpc.get_engine_client().start_workflow(
                     t.workflow.name,
                     t.workflow_input,
-                    description="workflow execution by cron trigger.",
+                    "workflow execution by cron trigger.",
                     **t.workflow_params
                 )
             finally:


### PR DESCRIPTION
After cron-trigger-create I got: https://bpaste.net/show/fa6f9049da77
Wrong parameters usage fixed.
