### PR TITLE
Complete eventlet removal and migrate to oslo.service threading backend

### DIFF
--- a/mistral/cmd/launch.py
+++ b/mistral/cmd/launch.py
@@ -14,20 +14,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-import sys
-
-import eventlet
-
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True)
-
-
 import os
+import sys
 
 
 # If ../mistral/__init__.py exists, add ../ to Python search path, so that
@@ -46,6 +34,7 @@ if os.path.exists(os.path.join(POSSIBLE_TOPDIR, 'mistral', '__init__.py')):
 from oslo_config import cfg
 from oslo_log import log as logging
 from oslo_service import service
+from oslo_service.backend import init_backend, BackendType
 
 from mistral.api import service as api_service
 from mistral import config
@@ -177,6 +166,9 @@ def get_properly_ordered_parameters():
 
 def main():
     try:
+        # Initialize threading backend early before any service components
+        init_backend(BackendType.THREADING)
+
         CONF.register_cli_opts(config.CLI_OPTS)
 
         config.parse_args(get_properly_ordered_parameters())

--- a/mistral/config.py
+++ b/mistral/config.py
@@ -186,15 +186,7 @@ js_impl_opt = cfg.StrOpt(
            'action to evaluate scripts.')
 )
 
-oslo_rpc_executor = cfg.StrOpt(
-    'oslo_rpc_executor',
-    default='threading',
-    choices=['eventlet', 'threading'],
-    deprecated_for_removal=True,
-    deprecated_reason='This option is going to be removed from oslo.messaging',
-    help=_('Executor type used by Oslo Messaging framework. Defines how '
-           'Oslo Messaging based RPC subsystem processes incoming calls.')
-)
+
 
 expiration_token_duration = cfg.IntOpt(
     'expiration_token_duration',
@@ -787,7 +779,7 @@ CONF.register_opt(wf_trace_log_name_opt)
 CONF.register_opt(auth_type_opt)
 CONF.register_opt(scheduler_type_opt)
 CONF.register_opt(js_impl_opt)
-CONF.register_opt(oslo_rpc_executor)
+
 CONF.register_opt(expiration_token_duration)
 CONF.register_opts(service_opts.service_opts)
 
@@ -829,7 +821,7 @@ default_group_opts = CLI_OPTS + [
     auth_type_opt,
     scheduler_type_opt,
     js_impl_opt,
-    oslo_rpc_executor,
+
     expiration_token_duration
 ]
 

--- a/mistral/engine/engine_server.py
+++ b/mistral/engine/engine_server.py
@@ -87,7 +87,7 @@ class EngineServer(service_base.MistralService):
         self._rpc_server = rpc.get_rpc_server_driver()(CONF.engine)
         self._rpc_server.register_endpoint(self)
 
-        self._rpc_server.run(executor=CONF.oslo_rpc_executor)
+        self._rpc_server.run(executor='threading')
 
         self._notify_started('Engine server started.')
 

--- a/mistral/tests/unit/__init__.py
+++ b/mistral/tests/unit/__init__.py
@@ -12,14 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import sys
+# Threading backend initialization for tests
+from oslo_service.backend import init_backend, BackendType
 
-import eventlet
-
-eventlet.monkey_patch(
-    os=True,
-    select=True,
-    socket=True,
-    thread=False if '--use-debugger' in sys.argv else True,
-    time=True
-)
+init_backend(BackendType.THREADING)

--- a/releasenotes/notes/complete-eventlet-removal-oslo-service-threading-backend-a1b2c3d4e5f6g7h8.yaml
+++ b/releasenotes/notes/complete-eventlet-removal-oslo-service-threading-backend-a1b2c3d4e5f6g7h8.yaml
@@ -1,0 +1,36 @@
+---
+upgrade:
+  - |
+    **Complete Eventlet Removal and Oslo.Service Threading Backend Migration**
+    
+    Mistral has completed its migration away from eventlet and now uses the
+    oslo.service threading backend exclusively. This represents the final step
+    in the eventlet removal process.
+
+    **Key Changes:**
+
+    * **Service Framework Migration**: Mistral now uses oslo.service's threading
+      backend instead of eventlet for service management. The threading backend
+      is initialized early in the application startup process.
+    * **Monkey Patching Removed**: All ``eventlet.monkey_patch()`` calls have been
+      removed from both the main service entry point (``cmd/launch.py``) and the
+      test suite initialization. This eliminates eventlet's modification of the
+      Python standard library.
+    * **RPC Executor Migration**: The deprecated ``oslo_rpc_executor`` configuration
+      option has been removed. All RPC servers (engine, executor, event-engine)
+      now use the threading executor exclusively.
+    * **Dependency Updates**: The ``eventlet`` dependency has been removed from
+      requirements.txt and replaced with the necessary oslo.service threading
+      backend dependencies.
+
+    **Configuration Impact:**
+
+    * If you were explicitly setting ``oslo_rpc_executor = threading`` in your
+      configuration, you can safely remove this setting as threading is now the
+      only supported executor type.
+    * No other configuration changes are required. Mistral services will
+      automatically use the threading backend.
+
+    This migration builds upon the extensive component-level eventlet removal work
+    completed in previous releases and represents the final step in Mistral's
+    modernization to a pure threading-based architecture.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ alembic>=0.9.6 # MIT
 croniter>=0.3.4 # MIT License
 cachetools>=2.0.0 # MIT License
 dogpile.cache>=0.6.2 # BSD
-eventlet>=0.27.0 # MIT
+
 Jinja2>=2.10 # BSD License (3 clause)
 jsonschema>=3.2.0 # MIT
 keystonemiddleware>=4.18.0 # Apache-2.0
@@ -23,7 +23,7 @@ oslo.policy>=4.5.0 # Apache-2.0
 oslo.utils>=7.0.0 # Apache-2.0
 oslo.log>=3.36.0 # Apache-2.0
 oslo.serialization>=2.21.1 # Apache-2.0
-oslo.service>=2.1.0 # Apache-2.0
+oslo.service[threading]>=4.2.2 # Apache-2.0
 osprofiler>=1.4.0 # Apache-2.0
 paramiko>=2.4.1 # LGPLv2.1+
 pbr!=2.1.0,>=2.0.0 # Apache-2.0


### PR DESCRIPTION
This commit completes Mistral's migration away from eventlet by implementing the oslo.service threading backend and removing all remaining eventlet usage.

Key changes:

Service Framework Migration:
- Initialize oslo.service threading backend in cmd/launch.py main()
- Initialize oslo.service threading backend in test suite (__init__.py)
- Remove all eventlet.monkey_patch() calls from service entry points

RPC Layer Migration:
- Remove deprecated 'oslo_rpc_executor' configuration option
- Hardcode threading executor for engine RPC server
- All RPC servers now consistently use threading (engine, executor, event-engine)

Dependency Management:
- Remove eventlet>=0.27.0 from requirements.txt
- Replace with oslo.service[threading]>=4.2.2 for threading backend support

This change builds upon the extensive component-level eventlet removal work completed in previous commits and represents the final step in modernizing Mistral to use a pure threading-based architecture.

The migration follows OpenStack community best practices and uses the official oslo.service threading backend as recommended in the eventlet removal guidelines.

Change-Id: Ic70543664528878517ac7917030a065f3b76c54d